### PR TITLE
Add support for material file uploads

### DIFF
--- a/src/materials/application/use-cases/create-material/create-material.contract.ts
+++ b/src/materials/application/use-cases/create-material/create-material.contract.ts
@@ -1,12 +1,10 @@
+import { Express } from 'express';
+
 export interface CreateMaterialContract {
-  execute(input: CreateMaterialInput): Promise<CreateMaterialOutput[]>;
+  execute(file: CreateMaterialInput): Promise<CreateMaterialOutput[]>;
 }
 
-export type CreateMaterialInput = {
-  buffer: Buffer;
-  originalname: string;
-  mimetype: string;
-};
+export type CreateMaterialInput = Express.Multer.File;
 
 export type CreateMaterialOutput = {
   file: string;

--- a/src/materials/presentation/controllers/materials.controller.ts
+++ b/src/materials/presentation/controllers/materials.controller.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiResponse } from '@nestjs/swagger';
+import { Express } from 'express';
 
 import { HttpCodeEnum } from '~_shared/constants/http-code.enum';
 import { CreateMaterialContract } from '~materials/application/use-cases/create-material/create-material.contract';
@@ -28,10 +29,8 @@ export class MaterialsController {
     type: CreateMaterialResponseDTO,
   })
   async create(
-    @UploadedFile() file: File,
+    @UploadedFile() file: Express.Multer.File,
   ): Promise<CreateMaterialResponseDTO[]> {
-    return this.createMaterial.execute({   buffer: file.arrayBuffer(),
-      originalname: file.or;
-      mimetype: string; });
+    return this.createMaterial.execute(file);
   }
 }


### PR DESCRIPTION
## Summary
- enable MaterialsController to receive `multer` files
- refactor create-material use case to use Express file buffers
- update material creation contract for Express file support

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing ESLint modules)*
- `npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf018ea0883208532e8ac62228f1a